### PR TITLE
fix(comment btn link error):

### DIFF
--- a/comment.js
+++ b/comment.js
@@ -254,7 +254,7 @@ var _renderHTML = function _renderHTML(params) {
     if (!comments_url) {
         issue_url = addr + "/" + username + "/" + repo + "/issues/new?title=" + issue_title + "#issue_body";
     } else {
-        issue_url = comments_url.replace(api_addr, addr).replace('comments', '') + '#new_comment_field';
+        issue_url = comments_url.replace(api_addr, addr).replace(/(.*)comments/, '$1') + '#new_comment_field';
     }
     var res = "\n        <p class=\"goto-comment\">\n        <a href=\"" + issue_url + "\" class=\"" + btn_class + "\" target=\"_blank\">" + go_to_comment + "</a>\n        </p>\n        ";
     $(comments_target).append(res);

--- a/src/comment-es6.js
+++ b/src/comment-es6.js
@@ -315,7 +315,7 @@ var _renderHTML = function (params) {
     if (!comments_url) {
         issue_url = `${ addr }/${ username }/${ repo }/issues/new?title=${ issue_title }#issue_body`;
     } else {
-        issue_url = comments_url.replace(api_addr, addr).replace('comments', '') + '#new_comment_field';
+        issue_url = comments_url.replace(api_addr, addr).replace(/(.*)comments/, '$1') + '#new_comment_field';
     }
     let res = `
         <p class="goto-comment">


### PR DESCRIPTION
hi, i found a bug when use comment.js in my blog. 

( i used 'blog-comments' as repo name)

Button link path is wrong when issue_id has already exist and repo name contains 'comments'.

as the last 'comments' in issue_url should be removed but not the first one.
